### PR TITLE
Fix script for creating rustc tags in interactive shell (fix #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ And now execute the following script inside of the rust directory:
 
     #!/usr/bin/env bash
     
-    src_dirs=`ls -d $PWD/src/{liballoc,libarena,libbacktrace,libcollections,libcore,libflate,libfmt_macros,libgetopts,libgraphviz,liblog,librand,librbml,libserialize,libstd,libsyntax,libterm}`
+    src_dirs=`echo $PWD/src/{liballoc,libarena,libbacktrace,libcollections,libcore,libflate,libfmt_macros,libgetopts,libgraphviz,liblog,librand,librbml,libserialize,libstd,libsyntax,libterm}`
     
     ctags -f rusty-tags.vi --options=src/etc/ctags.rust --languages=Rust --recurse $src_dirs
     

--- a/tools/make_rustc_tags
+++ b/tools/make_rustc_tags
@@ -11,7 +11,7 @@
 # 
 # And now execute the following script inside of the rust directory:
     
-src_dirs=`ls -d $PWD/src/{liballoc,libarena,libbacktrace,libcollections,libcore,libflate,libfmt_macros,libgetopts,libgraphviz,liblog,librand,librbml,libserialize,libstd,libsyntax,libterm}`
+src_dirs=`echo $PWD/src/{liballoc,libarena,libbacktrace,libcollections,libcore,libflate,libfmt_macros,libgetopts,libgraphviz,liblog,librand,librbml,libserialize,libstd,libsyntax,libterm}`
     
 ctags -f rusty-tags.vi --options=src/etc/ctags.rust --languages=Rust --recurse $src_dirs
 ctags -e -f rusty-tags.emacs --options=src/etc/ctags.rust --languages=Rust --recurse $src_dirs


### PR DESCRIPTION
ls was outputting shell color codes which was being misinterpreted by ctags as part of the filename, which then doesn't exist.