### PR TITLE
Permit missing 'package' tag in `Cargo.lock`

### DIFF
--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -38,15 +38,18 @@ pub fn read_dependencies(cargo_toml_dir: &Path) -> AppResult<TagsRoots>
       try!(parse_toml(&cargo_lock))
    };
 
-   let packages: Vec<&toml::Table> =
+   let default = toml::Value::Array(vec![]);
+   let packages: Vec<&toml::Table> = try!(
       lock_table.get("package")
+         .or(Some(&default))
          .and_then(toml::Value::as_slice)
          .map(|s| {
             s.iter()
              .filter_map(toml::Value::as_table)
              .collect()
          })
-         .unwrap_or(vec![]);
+         .ok_or(app_err_msg(format!("Couldn't get Array of Tables entry for 'package'!")))
+   );
 
    for package in packages.iter() {
       let lib_name = try!(

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -38,7 +38,7 @@ pub fn read_dependencies(cargo_toml_dir: &Path) -> AppResult<TagsRoots>
       try!(parse_toml(&cargo_lock))
    };
 
-   let packages: Vec<&toml::Table> = try!(
+   let packages: Vec<&toml::Table> =
       lock_table.get("package")
          .and_then(toml::Value::as_slice)
          .map(|s| {
@@ -46,8 +46,7 @@ pub fn read_dependencies(cargo_toml_dir: &Path) -> AppResult<TagsRoots>
              .filter_map(toml::Value::as_table)
              .collect()
          })
-         .ok_or(app_err_msg(format!("Couldn't get Array of Tables entry for 'package'!")))
-   );
+         .unwrap_or(vec![]);
 
    for package in packages.iter() {
       let lib_name = try!(


### PR DESCRIPTION
If a crate has zero dependencies, then no `[[package]]` sections appear in `Cargo.lock`.  For example, on a brand new crate, you will only find:

    [root]
    name = "empty"
    version = "0.1.0"

As such, a missing 'package' tag should be interpreted as an empty list rather than a hard error.

**Edit:** Ah, I missed the fact that `toml::Value::as_slice` can still legitimately fail. Will update.
**Edit 2:** Better now.