### PR TITLE
Allow non-static globals matching  to be recorded

### DIFF
--- a/src/tags.rs
+++ b/src/tags.rs
@@ -159,7 +159,7 @@ pub fn create_tags(tags_kind: &TagsKind, src_dir: &Path, tags_file: &Path) -> Ap
       .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?enum[ \\t]+([a-zA-Z0-9_]+)/\\2/g,enum,enumeration names/")
       .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?struct[ \\t]+([a-zA-Z0-9_]+)/\\2/s,structure names/")
       .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?mod[ \\t]+([a-zA-Z0-9_]+)/\\2/m,modules,module names/")
-      .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?static[ \\t]+([a-zA-Z0-9_]+)/\\2/c,consts,static constants/")
+      .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?(static|const)[ \\t]+([a-zA-Z0-9_]+)/\\3/c,consts,static constants/")
       .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?trait[ \\t]+([a-zA-Z0-9_]+)/\\2/t,traits,traits/")
       .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?impl([ \\t\\n]*<[^>]*>)?[ \\t]+(([a-zA-Z0-9_:]+)[ \\t]*(<[^>]*>)?[ \\t]+(for)[ \\t]+)?([a-zA-Z0-9_]+)/\\4 \\6 \\7/i,impls,trait implementations/")
       .arg("--regex-Rust=/^[ \\t]*macro_rules![ \\t]+([a-zA-Z0-9_]+)/\\1/d,macros,macro definitions/")


### PR DESCRIPTION
My project has a bunch of constants defined as
```rust
impl Color {
    ...
    pub const BLUE:   Color = Color(0x7C00);
    pub const MAG:    Color = Color(0x7C1F);
    pub const CYAN:   Color = Color(0x7FE0);
    pub const WHITE:  Color = Color(0x7FFF);
}
// --- sizes ---
const SCREEN_WIDTH: u32 = 240;
const SCREEN_HEIGHT: u32 = 160;
```

And this records them all as consts in the tags file too.  Before it only matched the  `static` keyword, not `const`.

If you have a better idea for scoping the constants inside an `impl`, I'm all for that too.