### PR TITLE
Use `copy` when moving tags file from cache dir to the target

### DIFF
--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1,4 +1,4 @@
-use std::fs::{File, OpenOptions, copy, rename, remove_file};
+use std::fs::{File, OpenOptions, copy, remove_file};
 use std::io::{Read, Write};
 use std::process::Command;
 use std::collections::HashSet;
@@ -144,7 +144,8 @@ pub fn move_tags(config: &Config, from_tags: &Path, to_tags: &Path) -> RtResult<
         println!("\nMove tags ...\n   from:\n      {}\n   to:\n      {}", from_tags.display(), to_tags.display());
     }
 
-    let _ = try!(rename(from_tags, to_tags));
+    try!(copy(from_tags, to_tags));
+    let _ = remove_file(from_tags);
     Ok(())
 }
 


### PR DESCRIPTION
This fixes the problem when cache dir is in different device than target
(happens when target is a symlink from another device, for example).