### PR TITLE
Implement new flag for omitting tags for deps

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,9 @@ pub struct Config {
     /// start directory for the search of the 'Cargo.toml'
     pub start_dir: PathBuf,
 
+    /// do not generate tags for dependencies
+    pub omit_deps: bool,
+
     /// forces the recreation of cached tags
     pub force_recreate: bool,
 
@@ -41,6 +44,7 @@ impl Config {
                 .value_names(&["DIR"])
                 .help("Start directory for the search of the Cargo.toml (default: current working directory)")
                 .takes_value(true))
+           .arg_from_usage("-o --omit-deps 'Do not generate tags for dependencies'")
            .arg_from_usage("-f --force-recreate 'Forces the recreation of all tags'")
            .arg_from_usage("-v --verbose 'Verbose output about all operations'")
            .arg_from_usage("-q --quiet 'Don't output anything but errors'")
@@ -53,6 +57,8 @@ impl Config {
        if ! start_dir.is_dir() {
            return Err(format!("Invalid directory given to '--start-dir': '{}'!", start_dir.display()).into());
        }
+
+       let omit_deps = matches.is_present("omit-deps");
 
        let quiet = matches.is_present("quiet");
        let kind = value_t_or_exit!(matches.value_of("TAGS_KIND"), TagsKind);
@@ -71,6 +77,7 @@ impl Config {
        Ok(Config {
            tags_spec: TagsSpec::new(kind, vi_tags, emacs_tags)?,
            start_dir: start_dir,
+           omit_deps: omit_deps,
            force_recreate: matches.is_present("force-recreate"),
            verbose: if quiet { false } else { matches.is_present("verbose") },
            quiet: quiet

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -74,11 +74,13 @@ fn build_dep_tree<'a>(config: &Config,
     let mut dep_tree = None;
     if let Some(pkg) = find_package(src_name, packages) {
         if let Some(src_path) = src_path(pkg, kind)? {
-            let dep_names = dependency_names(pkg)?;
             let mut dep_trees = Vec::new();
-            for name in &dep_names {
-                if let Some(tree) = build_dep_tree(config, name, SourceKind::Dep, packages, dep_graph)? {
-                    dep_trees.push(Box::new(tree));
+            if !config.omit_deps {
+                let dep_names = dependency_names(pkg)?;
+                for name in &dep_names {
+                    if let Some(tree) = build_dep_tree(config, name, SourceKind::Dep, packages, dep_graph)? {
+                        dep_trees.push(Box::new(tree));
+                    }
                 }
             }
 


### PR DESCRIPTION
Most of the time I only needs tags for the project I'm working on, not for dependencies. This flag implements an option for doing just that.