### PR TITLE
Use `|`, not `<bar>`, in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Vim Configuration
 Put this into your `~/.vimrc` file:
 
     autocmd BufRead *.rs :setlocal tags=./rusty-tags.vi;/
-    autocmd BufWrite *.rs :silent! exec "!rusty-tags vi --quiet --start-dir=" . expand('%:p:h') . "&" <bar> redraw!
+    autocmd BufWrite *.rs :silent! exec "!rusty-tags vi --quiet --start-dir=" . expand('%:p:h') . "&" | redraw!
 
 The first line (only supported by vim >= 7.4) ensures that vim will
 automatically search for a `rusty-tags.vi` file upwards the directory hierarchy.


### PR DESCRIPTION
The `<bar>` was causing an error in my neovim, but the | works.