### PR TITLE
Add more / sort executable paths

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -146,7 +146,7 @@ fn map_file<R, F>(file: &Path, f: F) -> RtResult<R>
 }
 
 fn detect_tags_exe() -> RtResult<TagsExe> {
-    for exe in &["ctags", "exuberant-ctags", "universal-ctags"] {
+    for exe in &["universal-ctags", "uctags", "exuberant-ctags", "exctags", "ctags"] {
         let mut cmd = Command::new(exe);
         cmd.arg("--version");
 


### PR DESCRIPTION
- They're called 'uctags' and 'exctags' in the official FreeBSD packages
- Prefer universal > exuberant > ctags