### PR TITLE
Support manifest paths that are not ancestors of source paths

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -262,8 +262,7 @@ pub struct Source {
 }
 
 impl Source {
-    pub fn new(id: SourceId, source_version: &SourceVersion, dir: &Path, is_root: bool, config: &Config) -> RtResult<Source> {
-        let cargo_toml_dir = find_dir_upwards_containing("Cargo.toml", dir)?;
+    pub fn new(id: SourceId, source_version: &SourceVersion, dir: &Path, cargo_toml_dir: &Path, is_root: bool, config: &Config) -> RtResult<Source> {
         let tags_file = cargo_toml_dir.join(config.tags_spec.file_name());
         let hash = source_hash(dir);
         let cached_tags_file = {


### PR DESCRIPTION
Allows building tags for dependencies whose `Cargo.toml` files do not
live in an ancestor directory of their source code path. We use the
manifest_path from `cargo metadata` directly rather than attempting to
reconstruct from the source path.