### PR TITLE
Correctly index unsafe traits

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -492,7 +492,7 @@ impl TagsSpec {
                    .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?struct[ \\t]+([a-zA-Z0-9_]+)/\\2/s,structure names/")
                    .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?mod[ \\t]+([a-zA-Z0-9_]+)\\s*\\{/\\2/m,modules,module names/")
                    .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?(static|const)[ \\t]+([a-zA-Z0-9_]+)/\\3/c,consts,static constants/")
-                   .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?trait[ \\t]+([a-zA-Z0-9_]+)/\\2/t,traits,traits/")
+                   .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?(unsafe[ \\t]+)?trait[ \\t]+([a-zA-Z0-9_]+)/\\3/t,traits,traits/")
                    .arg("--regex-Rust=/^[ \\t]*macro_rules![ \\t]+([a-zA-Z0-9_]+)/\\1/d,macros,macro definitions/");
 
                 cmd


### PR DESCRIPTION
The regex used to parse traits that is passed to ctags does not handle
unsafe traits; Any trait marked 'unsafe' is therefore not present in the
tag file. This fixes that by extending the regex to handle the
(optional) presence of 'unsafe', e.g. 'pub unsafe trait Foo'.