### PR TITLE
Index "test"-kind source paths

### DIFF
--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -160,7 +160,7 @@ fn source_path<'a>(config: &Config, package: &'a JsonValue) -> RtResult<Option<&
             let kind_str = kind.as_str()
                 .ok_or(format!("Expected 'kind' of type string but found: {}", to_string_pretty(kind)))?;
 
-            if kind_str != "bin" && ! kind_str.contains("lib") && kind_str != "proc-macro" {
+            if kind_str != "bin" && ! kind_str.contains("lib") && kind_str != "proc-macro" && kind_str != "test" {
                 verbose!(config, "Unsupported target kind: {}", kind_str);
                 continue;
             }


### PR DESCRIPTION
Previously the dependency kind "test" was not accepted by the dependencies logic, so test files were not indexed. This affected jumping between tags inside tests - since no ctags were generated for these files, there usually weren't tags to jump to.

I actually came across this from a slightly different angle: I have a workspace that has a root project containing only integration tests, i.e. no `lib` or `bin` types. So rusty-tags was not able to find the root project package because it had the following targets:

```json
            "id": "updater 0.1.0 (path+file:///Users/nick/projects/updater-ng/updater-ng)",
            "targets": [
                {
                    "crate_types": [
                        "bin"
                    ],
                    "edition": "2015",
                    "kind": [
                        "test"
                    ],
                    "name": "test_round_trip",
                    "src_path": "/Users/nick/projects/updater-ng/updater-ng/tests/test_round_trip.rs"
                },
                {
                    "crate_types": [
                        "bin"
                    ],
                    "edition": "2015",
                    "kind": [
                        "test"
                    ],
                    "name": "lib",
                    "src_path": "/Users/nick/projects/updater-ng/updater-ng/tests/lib.rs"
                }
            ],
```

Therefore the `updater` package never got added to the dependencies list, leading to a later error `Couldn't find package for (updater, 0.1.0)`

So this could be taken as a "feature" or a "bugfix" - kind of both. Let me know if you'd like me to reword anything.