### PR TITLE
Add command line option to set tags filename

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,7 @@ impl Config {
            return Err(format!("Invalid directory given to '--start-dir': '{}'!", start_dir.display()).into());
        }
 
+       let kind = value_t_or_exit!(matches.value_of("TAGS_KIND"), TagsKind);
 
        let (vi_tags, emacs_tags, ctags_exe, ctags_options) = {
            let mut vt = "rusty-tags.vi".to_string();
@@ -77,14 +78,17 @@ impl Config {
 
            // Override defaults with commandline options
            if let Some(cltf) = matches.value_of("output-name") {
-               vt = cltf.to_string();
-               et = cltf.to_string();
+
+               match kind {
+                   TagsKind::Vi    => vt = cltf.to_string(),
+                   TagsKind::Emacs => et = cltf.to_string()
+                   
+               }
            }
 
            (vt, et, cte, cto)
        };
 
-       let kind = value_t_or_exit!(matches.value_of("TAGS_KIND"), TagsKind);
        let omit_deps = matches.is_present("omit-deps");
        let force_recreate = matches.is_present("force-recreate");
        let quiet = matches.is_present("quiet");

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,7 @@ impl Config {
            .arg_from_usage("-v --verbose 'Verbose output about all operations'")
            .arg_from_usage("-q --quiet 'Don't output anything but errors'")
            .arg_from_usage("-n --num-threads [NUM] 'Num threads used for the tags creation (default: num available physical cpus)'")
+           .arg_from_usage("-O --output-name [FILENAME] 'Name of output tags file. Will use the same name for both vi and emacs'")
            .get_matches();
 
        let start_dir = matches.value_of("start-dir")
@@ -65,11 +66,19 @@ impl Config {
            let mut et = "rusty-tags.emacs".to_string();
            let mut cte = None;
            let mut cto = "".to_string();
+
+           // Override defaults with file config
            if let Some(file_config) = ConfigFromFile::load()? {
                if let Some(fcvt) = file_config.vi_tags { vt = fcvt; }
                if let Some(fcet) = file_config.emacs_tags { et = fcet; }
                cte = file_config.ctags_exe;
                if let Some(fccto) = file_config.ctags_options { cto = fccto; }
+           }
+
+           // Override defaults with commandline options
+           if let Some(cltf) = matches.value_of("output-name") {
+               vt = cltf.to_string();
+               et = cltf.to_string();
            }
 
            (vt, et, cte, cto)

--- a/src/types.rs
+++ b/src/types.rs
@@ -451,10 +451,6 @@ pub struct TagsSpec {
 
 impl TagsSpec {
     pub fn new(kind: TagsKind, exe: TagsExe, vi_tags: String, emacs_tags: String, ctags_options: String) -> RtResult<TagsSpec> {
-        if vi_tags == emacs_tags {
-            return Err(format!("It's not supported to use the same tags name '{}' for vi and emacs!", vi_tags).into());
-        }
-
         Ok(TagsSpec {
             kind: kind,
             exe: exe,

--- a/src/types.rs
+++ b/src/types.rs
@@ -451,6 +451,10 @@ pub struct TagsSpec {
 
 impl TagsSpec {
     pub fn new(kind: TagsKind, exe: TagsExe, vi_tags: String, emacs_tags: String, ctags_options: String) -> RtResult<TagsSpec> {
+        if vi_tags == emacs_tags {
+            return Err(format!("It's not supported to use the same tags name '{}' for vi and emacs!", vi_tags).into());
+        }
+
         Ok(TagsSpec {
             kind: kind,
             exe: exe,


### PR DESCRIPTION
Adds an option to set the output filename from the command line rather than needing to use a global config file.

To support this, removes the restriction and vi and emacs filenames can't be the same. From a config file perspective I think the user can be trusted to understand the consequences of naming the files the same thing.