### PR TITLE
Add command line option to set tags filename v2

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,7 @@ impl Config {
            .arg_from_usage("-v --verbose 'Verbose output about all operations'")
            .arg_from_usage("-q --quiet 'Don't output anything but errors'")
            .arg_from_usage("-n --num-threads [NUM] 'Num threads used for the tags creation (default: num available physical cpus)'")
+           .arg_from_usage("-O --output [FILENAME] 'Name of output tags file. Will use the same name for both vi and emacs'")
            .get_matches();
 
        let start_dir = matches.value_of("start-dir")
@@ -59,12 +60,15 @@ impl Config {
            return Err(format!("Invalid directory given to '--start-dir': '{}'!", start_dir.display()).into());
        }
 
+       let kind = value_t_or_exit!(matches.value_of("TAGS_KIND"), TagsKind);
 
        let (vi_tags, emacs_tags, ctags_exe, ctags_options) = {
            let mut vt = "rusty-tags.vi".to_string();
            let mut et = "rusty-tags.emacs".to_string();
            let mut cte = None;
            let mut cto = "".to_string();
+
+           // Override defaults with file config
            if let Some(file_config) = ConfigFromFile::load()? {
                if let Some(fcvt) = file_config.vi_tags { vt = fcvt; }
                if let Some(fcet) = file_config.emacs_tags { et = fcet; }
@@ -72,10 +76,19 @@ impl Config {
                if let Some(fccto) = file_config.ctags_options { cto = fccto; }
            }
 
+           // Override defaults with commandline options
+           if let Some(cltf) = matches.value_of("output-name") {
+
+               match kind {
+                   TagsKind::Vi    => vt = cltf.to_string(),
+                   TagsKind::Emacs => et = cltf.to_string()
+                   
+               }
+           }
+
            (vt, et, cte, cto)
        };
 
-       let kind = value_t_or_exit!(matches.value_of("TAGS_KIND"), TagsKind);
        let omit_deps = matches.is_present("omit-deps");
        let force_recreate = matches.is_present("force-recreate");
        let quiet = matches.is_present("quiet");


### PR DESCRIPTION
Adds an option to set the output filename from the command line rather than needing to use a global config file.