### PR TITLE
Adjust ctags regexp to accept pub(crate) declarations

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -486,13 +486,13 @@ impl TagsSpec {
                 cmd.arg("--languages=Rust")
                    .arg("--langdef=Rust")
                    .arg("--langmap=Rust:.rs")
-                   .arg("--regex-Rust=/^[ \\t]*(#\\[[^\\]]\\][ \\t]*)*(pub[ \\t]+)?(extern[ \\t]+)?(\"[^\"]+\"[ \\t]+)?(unsafe[ \\t]+)?fn[ \\t]+([a-zA-Z0-9_]+)/\\6/f,functions,function definitions/")
-                   .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?type[ \\t]+([a-zA-Z0-9_]+)/\\2/T,types,type definitions/")
-                   .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?enum[ \\t]+([a-zA-Z0-9_]+)/\\2/g,enum,enumeration names/")
-                   .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?struct[ \\t]+([a-zA-Z0-9_]+)/\\2/s,structure names/")
-                   .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?mod[ \\t]+([a-zA-Z0-9_]+)\\s*\\{/\\2/m,modules,module names/")
-                   .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?(static|const)[ \\t]+([a-zA-Z0-9_]+)/\\3/c,consts,static constants/")
-                   .arg("--regex-Rust=/^[ \\t]*(pub[ \\t]+)?(unsafe[ \\t]+)?trait[ \\t]+([a-zA-Z0-9_]+)/\\3/t,traits,traits/")
+                   .arg("--regex-Rust=/^[ \\t]*(#\\[[^\\]]\\][ \\t]*)*(pub(\\(crate\\)?)[ \\t]+)?(extern[ \\t]+)?(\"[^\"]+\"[ \\t]+)?(unsafe[ \\t]+)?fn[ \\t]+([a-zA-Z0-9_]+)/\\7/f,functions,function definitions/")
+                   .arg("--regex-Rust=/^[ \\t]*(pub(\\(crate\\))?[ \\t]+)?type[ \\t]+([a-zA-Z0-9_]+)/\\3/T,types,type definitions/")
+                   .arg("--regex-Rust=/^[ \\t]*(pub(\\(crate\\))?[ \\t]+)?enum[ \\t]+([a-zA-Z0-9_]+)/\\3/g,enum,enumeration names/")
+                   .arg("--regex-Rust=/^[ \\t]*(pub(\\(crate\\))?[ \\t]+)?struct[ \\t]+([a-zA-Z0-9_]+)/\\3/s,structure names/")
+                   .arg("--regex-Rust=/^[ \\t]*(pub(\\(crate\\))?[ \\t]+)?mod[ \\t]+([a-zA-Z0-9_]+)\\s*\\{/\\3/m,modules,module names/")
+                   .arg("--regex-Rust=/^[ \\t]*(pub(\\(crate\\))?[ \\t]+)?(static|const)[ \\t]+([a-zA-Z0-9_]+)/\\4/c,consts,static constants/")
+                   .arg("--regex-Rust=/^[ \\t]*(pub(\\(crate\\))?[ \\t]+)?(unsafe[ \\t]+)?trait[ \\t]+([a-zA-Z0-9_]+)/\\4/t,traits,traits/")
                    .arg("--regex-Rust=/^[ \\t]*macro_rules![ \\t]+([a-zA-Z0-9_]+)/\\1/d,macros,macro definitions/");
 
                 cmd


### PR DESCRIPTION
Previously, no tags was created for crate-public declared functions,
like following:

	pub(crate) fn foo(x: u32) { /* body */ }