### PR TITLE
Fix warning about implicit dyn being deprecated

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -57,7 +57,7 @@ impl DepTree {
         Sources::new(&self.sources, self.dependencies_slice(source))
     }
 
-    pub fn all_sources<'a>(&'a self) -> Box<Iterator<Item=&Source> + 'a> {
+    pub fn all_sources<'a>(&'a self) -> Box<dyn Iterator<Item=&Source> + 'a> {
         Box::new(self.sources
                      .iter()
                      .filter_map(|s| s.as_ref()))


### PR DESCRIPTION
Rust made trait objects with implicit `dyn` keyword deprecated. This caused a warning during compilation:
```
warning: trait objects without an explicit `dyn` are deprecated
  --> src/types.rs:60:45
   |
60 |     pub fn all_sources<'a>(&'a self) -> Box<Iterator<Item=&Source> + 'a> {
   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `
dyn Iterator<Item=&Source> + 'a`
   |
   = note: `#[warn(bare_trait_objects)]` on by default
```
this patch fixes that by adding the `dyn` keyword