### PR TITLE
Enable Link-Time Optimization for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ serde_json = "1.0.38"
 fnv = "1.0.6"
 semver = "0.9.0"
 dirs = "2.0"
+
+[profile.release]
+lto = "fat"


### PR DESCRIPTION
LTO produces slightly smaller binaries and can potentially make it faster as well due to the removal of unused code. It lengthens compilation by a few seconds but that shouldn't be a big issue since it's only performed on release builds.

On my Linux system, it shaves 200kB off the end binary. I didn't benchmark it since `rusty-tags` is already very fast.